### PR TITLE
fix: Constant __TYPECHO_ADMIN__ already defined

### DIFF
--- a/Links/manage-links.php
+++ b/Links/manage-links.php
@@ -1,5 +1,4 @@
 <?php
-include 'common.php';
 include 'header.php';
 include 'menu.php';
 ?>


### PR DESCRIPTION
`include 'common.php';` in `manage-links.php` is duplicated.

### admin/extending.php

```php
<?php
include 'common.php';

// first import common.php
// then load custom panel
```